### PR TITLE
Loosen address regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub fn decode(bin: &[u8], dump: &str) -> ReturnType {
     };
 
     // Match everything that looks like a program address
-    let re = Regex::new(r"(40[0-9a-fA-F]{6})\b").unwrap();
+    let re = Regex::new(r"([0-9a-fA-F]{8})\b").unwrap();
     for cap in re.captures_iter(dump) {
         let address = u64::from_str_radix(&cap[0], 16).unwrap();
         // Look for frame that contains the address


### PR DESCRIPTION
It seems that the current regex parser specifically looks for addresses by finding an 8-character hexadecimal string starting with `40`. However, as discovered [here](https://discord.com/channels/429907082951524364/1306397361521692732/1306418112194805800), the addresses don't always start with `40`.

I'm guessing this was added to avoid catching other random 8-digit numbers or words that happen to only use the letters A-F, but I think some potential false matches would be preferable to not decoding the trace at all.

Alternatively/additionally, we could also look to see that they have the `0x` prefix, but I'm not sure if that is always the case.