### PR TITLE
Relax address regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub fn decode(bin: &[u8], dump: &str) -> ReturnType {
     };
 
     // Match everything that looks like a program address
-    let re = Regex::new(r"(40[0-9a-fA-F]{6})\b").unwrap();
+    let re = Regex::new(r"(4[0-9a-fA-F]{7})\b").unwrap();
     for cap in re.captures_iter(dump) {
         let address = u64::from_str_radix(&cap[0], 16).unwrap();
         // Look for frame that contains the address


### PR DESCRIPTION
As raised in #4 limiting the address detection to those starting with `40` means that doesn't detect addresses starting with `42` or other non-`40`s, etc.

This relaxes the regex to match any 8-char hexadecimal string starting with `4` instead of `40`